### PR TITLE
feat: Add Terraform API-based server deletion by OpenStack server ID

### DIFF
--- a/src/main/java/com/example/terraformapi/controller/InstanceController.java
+++ b/src/main/java/com/example/terraformapi/controller/InstanceController.java
@@ -40,4 +40,14 @@ public class InstanceController {
         instanceService.deleteInstance(id);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/openstack/{serverId}")
+    public ResponseEntity<String> deleteInstanceByServerId(@PathVariable String serverId) {
+        try {
+            instanceService.deleteInstanceByServerId(serverId);
+            return ResponseEntity.ok("서버 " + serverId + " 삭제 완료");
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("서버 삭제 실패: " + e.getMessage());
+        }
+    }
 } 

--- a/src/main/java/com/example/terraformapi/service/TerraformService.java
+++ b/src/main/java/com/example/terraformapi/service/TerraformService.java
@@ -160,4 +160,44 @@ public class TerraformService {
             throw new RuntimeException("Terraform 실행 취소 실패", e);
         }
     }
+
+    /**
+     * Terraform Cloud에서 destroy run을 생성합니다.
+     */
+    public String createDestroyRun(String serverId) {
+        String url = apiUrl + "/runs";
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.valueOf("application/vnd.api+json"));
+        headers.setBearerAuth(token);
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("data", Map.of(
+            "type", "runs",
+            "attributes", Map.of(
+                "message", "Destroy OpenStack instance: " + serverId,
+                "is-destroy", true,
+                "auto-apply", true
+            ),
+            "relationships", Map.of(
+                "workspace", Map.of(
+                    "data", Map.of(
+                        "type", "workspaces",
+                        "id", workspaceId
+                    )
+                )
+            )
+        ));
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
+        
+        try {
+            ResponseEntity<Map> response = restTemplate.postForEntity(url, request, Map.class);
+            Map<String, Object> data = (Map<String, Object>) response.getBody().get("data");
+            return (String) data.get("id");
+        } catch (Exception e) {
+            log.error("Terraform destroy 실행 생성 실패", e);
+            throw new RuntimeException("Terraform destroy 실행 생성 실패", e);
+        }
+    }
 } 


### PR DESCRIPTION
- Add deleteInstanceByServerId API endpoint in InstanceController
- Add createDestroyRun method in TerraformService for destroy operations
- Update InstanceService to use Terraform API instead of OpenStack API
- Remove OpenStack API direct calls for server deletion
- Set instance status to DELETING when deletion is triggered

API Usage: DELETE /api/instances/openstack/{serverId}